### PR TITLE
Migrations for non-abstract models only

### DIFF
--- a/image_assets/migrations/0002_models_localization.py
+++ b/image_assets/migrations/0002_models_localization.py
@@ -3,6 +3,7 @@
 from django.db import migrations, models
 import django.db.models.deletion
 import image_assets.models
+from image_assets import defaults
 
 
 class Migration(migrations.Migration):
@@ -12,57 +13,84 @@ class Migration(migrations.Migration):
         ('image_assets', '0001_initial'),
     ]
 
-    operations = [
-        migrations.AlterModelOptions(
-            name='asset',
-            options={'verbose_name': 'Asset', 'verbose_name_plural': 'Assets'},
-        ),
-        migrations.AlterModelOptions(
-            name='assettype',
-            options={'verbose_name': 'Asset Type', 'verbose_name_plural': 'Asset Types'},
-        ),
-        migrations.AlterModelOptions(
-            name='deletedasset',
-            options={'verbose_name': 'Deleted Asset', 'verbose_name_plural': 'Deleted Assets'},
-        ),
-        migrations.AlterField(
-            model_name='asset',
-            name='active',
-            field=models.BooleanField(default=True, verbose_name='Active'),
-        ),
-        migrations.AlterField(
-            model_name='asset',
-            name='asset_type',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='image_assets.AssetType', verbose_name='Asset Type'),
-        ),
-        migrations.AlterField(
-            model_name='asset',
-            name='content_type',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='contenttypes.ContentType', verbose_name='Content Type'),
-        ),
-        migrations.AlterField(
-            model_name='asset',
-            name='image',
-            field=models.ImageField(upload_to='', validators=[image_assets.models.AssetType.validate_asset], verbose_name='Image'),
-        ),
-        migrations.AlterField(
-            model_name='asset',
-            name='object_id',
-            field=models.IntegerField(verbose_name='Object ID'),
-        ),
-        migrations.AlterField(
-            model_name='assettype',
-            name='allowed_for',
-            field=models.ManyToManyField(blank=True, related_name='allowed_asset_types', related_query_name='allowed_asset_types', to='contenttypes.ContentType', verbose_name='Allowed for'),
-        ),
-        migrations.AlterField(
-            model_name='assettype',
-            name='slug',
-            field=models.SlugField(unique=True, verbose_name='Slug'),
-        ),
-        migrations.AlterField(
-            model_name='assettype',
-            name='required_for',
-            field=models.ManyToManyField(blank=True, related_name='required_asset_types', related_query_name='required_asset_types', to='contenttypes.ContentType', verbose_name='Required for'),
-        ),
-    ]
+    operations = []
+
+    if defaults.ASSET_TYPE_MODEL == 'image_assets.AssetType':
+        operations.extend([
+            migrations.AlterModelOptions(
+                name='assettype',
+                options={'verbose_name': 'Asset Type',
+                         'verbose_name_plural': 'Asset Types'},
+            ),
+            migrations.AlterField(
+                model_name='assettype',
+                name='allowed_for',
+                field=models.ManyToManyField(blank=True,
+                                             related_name='allowed_asset_types',
+                                             related_query_name='allowed_asset_types',
+                                             to='contenttypes.ContentType',
+                                             verbose_name='Allowed for'),
+            ),
+            migrations.AlterField(
+                model_name='assettype',
+                name='slug',
+                field=models.SlugField(unique=True, verbose_name='Slug'),
+            ),
+            migrations.AlterField(
+                model_name='assettype',
+                name='required_for',
+                field=models.ManyToManyField(blank=True,
+                                             related_name='required_asset_types',
+                                             related_query_name='required_asset_types',
+                                             to='contenttypes.ContentType',
+                                             verbose_name='Required for'),
+            ),
+        ])
+    if defaults.ASSET_MODEL == 'image_assets.Asset':
+        operations.extend([
+            migrations.AlterModelOptions(
+                name='asset',
+                options={'verbose_name': 'Asset', 'verbose_name_plural': 'Assets'},
+            ),
+            migrations.AlterField(
+                model_name='asset',
+                name='active',
+                field=models.BooleanField(default=True, verbose_name='Active'),
+            ),
+            migrations.AlterField(
+                model_name='asset',
+                name='asset_type',
+                field=models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    to='image_assets.AssetType', verbose_name='Asset Type'),
+            ),
+            migrations.AlterField(
+                model_name='asset',
+                name='content_type',
+                field=models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    to='contenttypes.ContentType', verbose_name='Content Type'),
+            ),
+            migrations.AlterField(
+                model_name='asset',
+                name='image',
+                field=models.ImageField(upload_to='', validators=[
+                    image_assets.models.AssetType.validate_asset],
+                                        verbose_name='Image'),
+            ),
+            migrations.AlterField(
+                model_name='asset',
+                name='object_id',
+                field=models.IntegerField(verbose_name='Object ID'),
+            ),
+
+        ])
+    if defaults.DELETED_ASSET_MODEL == 'image_assets.DeletedAsset':
+        operations.extend([
+            migrations.AlterModelOptions(
+                name='deletedasset',
+                options={'verbose_name': 'Deleted Asset',
+                         'verbose_name_plural': 'Deleted Assets'},
+            ),
+
+        ])


### PR DESCRIPTION
When creating new migrations for test project, we must check whether migrations are not created for abstract models. After `makemigrations` new migration should be edited and all operations should be wrapped with code:
```
if defaults.ASSET_MODEL == 'image_assets.Asset':
   ...

# etc...
```