### PR TITLE
Fix data migration

### DIFF
--- a/image_assets/migrations/0006_migrate_formats.py
+++ b/image_assets/migrations/0006_migrate_formats.py
@@ -6,23 +6,23 @@ from image_assets import defaults
 
 # noinspection PyUnusedLocal
 def migrate_formats(apps, schema_editor):
-    app_label, model_name = defaults.ASSET_TYPE_MODEL.split('.')
     # noinspection PyPep8Naming
-    AssetType = apps.get_model(app_label, model_name)
-    formats = AssetType._meta.get_field('formats')
+    AssetType = apps.get_model('image_assets', 'AssetType')
 
     for at in AssetType.objects.all():
-        flag = getattr(formats, at.format)
+        flag = getattr(AssetType.formats, at.format)
         at.formats = flag
         at.save()
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('image_assets', '0005_assettype_formats'),
     ]
 
-    operations = [
-        migrations.RunPython(migrate_formats, migrations.RunPython.noop),
-    ]
+    operations = []
+
+    if defaults.ASSET_TYPE_MODEL == 'image_assets.AssetType':
+        operations.extend([
+            migrations.RunPython(migrate_formats, migrations.RunPython.noop),
+        ])

--- a/image_assets/migrations/0006_migrate_formats.py
+++ b/image_assets/migrations/0006_migrate_formats.py
@@ -9,9 +9,10 @@ def migrate_formats(apps, schema_editor):
     app_label, model_name = defaults.ASSET_TYPE_MODEL.split('.')
     # noinspection PyPep8Naming
     AssetType = apps.get_model(app_label, model_name)
+    formats = AssetType._meta.get_field('formats')
 
     for at in AssetType.objects.all():
-        flag = getattr(AssetType.formats, at.format)
+        flag = getattr(formats, at.format)
         at.formats = flag
         at.save()
 


### PR DESCRIPTION
The problem with overriden AssetType model is that migration dependency is broken:

* formats data migration in `image_assets` must be applied before deletion of format field in `assets`
* formats field must be applied after adding formats field in `assets`

While first dependency could be established in `assets` migration, second dependency belongs to `image_assets` library and could not be set up properly.
The solution is to disable data migration for abstract AssetType model in favor of copying this migration to an `assets` application.